### PR TITLE
Histórico de buscas

### DIFF
--- a/app/src/main/java/br/com/podesenvolver/data/local/AppDatabase.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/AppDatabase.kt
@@ -8,7 +8,7 @@ import br.com.podesenvolver.data.local.dao.PodcastWithEpisodesDao
 import br.com.podesenvolver.data.local.entity.EpisodeEntity
 import br.com.podesenvolver.data.local.entity.PodcastEntity
 
-@Database(entities = [PodcastEntity::class, EpisodeEntity::class], version = 6)
+@Database(entities = [PodcastEntity::class, EpisodeEntity::class], version = 7)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun getPodcastDataAccessObject(): PodcastDao
     abstract fun getEpisodeDataAccessObject(): EpisodeDao

--- a/app/src/main/java/br/com/podesenvolver/data/local/AppDatabase.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/AppDatabase.kt
@@ -8,7 +8,7 @@ import br.com.podesenvolver.data.local.dao.PodcastWithEpisodesDao
 import br.com.podesenvolver.data.local.entity.EpisodeEntity
 import br.com.podesenvolver.data.local.entity.PodcastEntity
 
-@Database(entities = [PodcastEntity::class, EpisodeEntity::class], version = 7)
+@Database(entities = [PodcastEntity::class, EpisodeEntity::class], version = 8)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun getPodcastDataAccessObject(): PodcastDao
     abstract fun getEpisodeDataAccessObject(): EpisodeDao

--- a/app/src/main/java/br/com/podesenvolver/data/local/AppDatabase.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/AppDatabase.kt
@@ -8,7 +8,7 @@ import br.com.podesenvolver.data.local.dao.PodcastWithEpisodesDao
 import br.com.podesenvolver.data.local.entity.EpisodeEntity
 import br.com.podesenvolver.data.local.entity.PodcastEntity
 
-@Database(entities = [PodcastEntity::class, EpisodeEntity::class], version = 5)
+@Database(entities = [PodcastEntity::class, EpisodeEntity::class], version = 6)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun getPodcastDataAccessObject(): PodcastDao
     abstract fun getEpisodeDataAccessObject(): EpisodeDao

--- a/app/src/main/java/br/com/podesenvolver/data/local/DatabaseConfig.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/DatabaseConfig.kt
@@ -7,7 +7,6 @@ class DatabaseConfig {
     companion object {
         fun create(application: Application) =
             Room.databaseBuilder(application, AppDatabase::class.java, "podesenvolver-database")
-                .fallbackToDestructiveMigration()
                 .build()
     }
 }

--- a/app/src/main/java/br/com/podesenvolver/data/local/dao/PodcastDao.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/dao/PodcastDao.kt
@@ -2,6 +2,8 @@ package br.com.podesenvolver.data.local.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
 import br.com.podesenvolver.data.local.entity.PodcastEntity
 
 @Dao
@@ -9,4 +11,8 @@ interface PodcastDao {
 
     @Insert
     suspend fun insert(podcast: PodcastEntity): Long
+
+    @Transaction
+    @Query("DELETE FROM Podcast WHERE id=:podcastId")
+    suspend fun deleteById(podcastId: Long)
 }

--- a/app/src/main/java/br/com/podesenvolver/data/local/dao/PodcastWithEpisodesDao.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/dao/PodcastWithEpisodesDao.kt
@@ -9,7 +9,7 @@ import br.com.podesenvolver.data.local.entity.PodcastWithEpisodesEntity
 interface PodcastWithEpisodesDao {
 
     @Transaction
-    @Query("SELECT * FROM Podcast LIMIT 5")
+    @Query("SELECT * FROM Podcast ORDER BY created_at DESC LIMIT 5")
     suspend fun getRecent(): List<PodcastWithEpisodesEntity>
 
     @Transaction

--- a/app/src/main/java/br/com/podesenvolver/data/local/entity/EpisodeEntity.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/entity/EpisodeEntity.kt
@@ -2,9 +2,21 @@ package br.com.podesenvolver.data.local.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "Episode")
+@Entity(
+    tableName = "Episode",
+    foreignKeys = [
+        ForeignKey(
+            entity = PodcastEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["podcast_id"],
+            onDelete = ForeignKey.CASCADE,
+            onUpdate = ForeignKey.CASCADE
+        )
+    ]
+)
 data class EpisodeEntity(
     @PrimaryKey(autoGenerate = true) val id: Long,
     @ColumnInfo(name = "index") val index: Int,

--- a/app/src/main/java/br/com/podesenvolver/data/local/entity/PodcastEntity.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/entity/PodcastEntity.kt
@@ -15,4 +15,5 @@ data class PodcastEntity(
     @ColumnInfo(name = "description") val description: String,
     @ColumnInfo(name = "category") val category: String,
     @ColumnInfo(name = "rssUrl") val rssUrl: String,
+    @ColumnInfo(name = "created_at") val createdAt: Long
 )

--- a/app/src/main/java/br/com/podesenvolver/data/local/entity/PodcastEntity.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/entity/PodcastEntity.kt
@@ -6,7 +6,9 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = "Podcast")
 data class PodcastEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long,
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id")
+    val id: Long,
     @ColumnInfo(name = "title") val title: String,
     @ColumnInfo(name = "image_url") val imageUrl: String,
     @ColumnInfo(name = "author") val author: String,

--- a/app/src/main/java/br/com/podesenvolver/data/local/entity/PodcastEntity.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/entity/PodcastEntity.kt
@@ -13,5 +13,6 @@ data class PodcastEntity(
     @ColumnInfo(name = "image_url") val imageUrl: String,
     @ColumnInfo(name = "author") val author: String,
     @ColumnInfo(name = "description") val description: String,
-    @ColumnInfo(name = "category") val category: String
+    @ColumnInfo(name = "category") val category: String,
+    @ColumnInfo(name = "rssUrl") val rssUrl: String,
 )

--- a/app/src/main/java/br/com/podesenvolver/data/local/mapper/PodcastWithEpisodesMapper.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/mapper/PodcastWithEpisodesMapper.kt
@@ -11,5 +11,6 @@ fun PodcastWithEpisodesEntity.toDomain(): Podcast =
         description = this.podcast.description,
         category = this.podcast.category,
         episodes = this.episodes.map { it.toDomain() },
-        cacheId = this.podcast.id
+        cacheId = this.podcast.id,
+        rssUrl = this.podcast.rssUrl
     )

--- a/app/src/main/java/br/com/podesenvolver/data/local/repository/LocalPodcastRepository.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/repository/LocalPodcastRepository.kt
@@ -8,4 +8,5 @@ interface LocalPodcastRepository {
     suspend fun getRecentPodcasts(): List<Podcast>
     suspend fun getPodcastById(id: Long): Podcast?
     suspend fun getEpisodeById(episodeId: Long): Episode?
+    suspend fun deletePodcastById(podcastId: Long)
 }

--- a/app/src/main/java/br/com/podesenvolver/data/local/repository/LocalPodcastRepositoryImpl.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/repository/LocalPodcastRepositoryImpl.kt
@@ -20,7 +20,8 @@ class LocalPodcastRepositoryImpl(
             author = podcast.author,
             description = podcast.description,
             category = podcast.category,
-            rssUrl = podcast.rssUrl
+            rssUrl = podcast.rssUrl,
+            createdAt = System.currentTimeMillis()
         )
 
         val podcastEntityId = appDatabase.getPodcastDataAccessObject().insert(podcastEntity)

--- a/app/src/main/java/br/com/podesenvolver/data/local/repository/LocalPodcastRepositoryImpl.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/repository/LocalPodcastRepositoryImpl.kt
@@ -19,7 +19,8 @@ class LocalPodcastRepositoryImpl(
             imageUrl = podcast.imageUrl,
             author = podcast.author,
             description = podcast.description,
-            category = podcast.category
+            category = podcast.category,
+            rssUrl = podcast.rssUrl
         )
 
         val podcastEntityId = appDatabase.getPodcastDataAccessObject().insert(podcastEntity)

--- a/app/src/main/java/br/com/podesenvolver/data/local/repository/LocalPodcastRepositoryImpl.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/local/repository/LocalPodcastRepositoryImpl.kt
@@ -49,4 +49,7 @@ class LocalPodcastRepositoryImpl(
 
     override suspend fun getEpisodeById(episodeId: Long): Episode? =
         appDatabase.getEpisodeDataAccessObject().getById(episodeId)?.toDomain()
+
+    override suspend fun deletePodcastById(podcastId: Long) =
+        appDatabase.getPodcastDataAccessObject().deleteById(podcastId)
 }

--- a/app/src/main/java/br/com/podesenvolver/data/network/mapper/RssChannelMapper.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/network/mapper/RssChannelMapper.kt
@@ -3,11 +3,12 @@ package br.com.podesenvolver.data.network.mapper
 import br.com.podesenvolver.domain.Podcast
 import tw.ktrssreader.kotlin.model.channel.ITunesChannelData
 
-fun ITunesChannelData.toDomain() = Podcast(
+fun ITunesChannelData.toDomain(rssUrl: String) = Podcast(
     title = this.title.orEmpty(),
     imageUrl = this.image?.url.orEmpty(),
     author = this.author.orEmpty(),
     description = this.description.orEmpty(),
     category = this.categories.orEmpty().firstOrNull()?.name.orEmpty(),
-    episodes = this.items?.mapIndexed { index, item -> item.toDomain(index) }.orEmpty()
+    episodes = this.items?.mapIndexed { index, item -> item.toDomain(index) }.orEmpty(),
+    rssUrl = rssUrl
 )

--- a/app/src/main/java/br/com/podesenvolver/data/network/repository/PodcastRepositoryImpl.kt
+++ b/app/src/main/java/br/com/podesenvolver/data/network/repository/PodcastRepositoryImpl.kt
@@ -6,5 +6,5 @@ import br.com.podesenvolver.domain.Podcast
 
 class PodcastRepositoryImpl(private val podcastDataSource: PodcastDataSource) : PodcastRepository {
     override suspend fun getPodcast(url: String): Podcast =
-        podcastDataSource.getPodcast(url).toDomain()
+        podcastDataSource.getPodcast(url).toDomain(url)
 }

--- a/app/src/main/java/br/com/podesenvolver/domain/Podcast.kt
+++ b/app/src/main/java/br/com/podesenvolver/domain/Podcast.kt
@@ -7,5 +7,6 @@ data class Podcast(
     val author: String,
     val description: String,
     val category: String,
-    val cacheId: Long = 0
+    val cacheId: Long = 0,
+    val rssUrl: String
 )

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedActivity.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedActivity.kt
@@ -54,7 +54,7 @@ class RSSFeedActivity : ComponentActivity() {
                             onSearch = { rssUrl -> viewModel.fetchPodcast(rssUrl) },
                             lastPodcastsState = lastPodcastsState,
                             onClearPodcastFromHistory = { viewModel.deletePodcastFromHistory(it) },
-                            onClickPodcastInHistory = { viewModel.fetchPodcast(it.rssUrl) }
+                            onClickPodcastInHistory = { viewModel.selectPodcastFromHistory(it) }
                         )
                     }
                 }

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedActivity.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedActivity.kt
@@ -53,7 +53,8 @@ class RSSFeedActivity : ComponentActivity() {
                             fetchingPodcast = fetchingPodcast,
                             onSearch = { rssUrl -> viewModel.fetchPodcast(rssUrl) },
                             lastPodcastsState = lastPodcastsState,
-                            onClearPodcastFromHistory = { viewModel.deletePodcastFromHistory(it) }
+                            onClearPodcastFromHistory = { viewModel.deletePodcastFromHistory(it) },
+                            onClickPodcastInHistory = { viewModel.fetchPodcast(it.rssUrl) }
                         )
                     }
                 }

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedActivity.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -41,6 +42,7 @@ class RSSFeedActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             val fetchingPodcast by remember { viewModel.fetchingPodcast }
+            val lastPodcastsState by viewModel.lastPodcasts.collectAsState()
 
             FetchErrorDialogAlert()
 
@@ -49,7 +51,9 @@ class RSSFeedActivity : ComponentActivity() {
                     Box(Modifier.padding(it)) {
                         RSSFeedUI(
                             fetchingPodcast = fetchingPodcast,
-                            onSearch = { rssUrl -> viewModel.fetchPodcast(rssUrl) }
+                            onSearch = { rssUrl -> viewModel.fetchPodcast(rssUrl) },
+                            lastPodcastsState = lastPodcastsState,
+                            onClearPodcastFromHistory = { viewModel.deletePodcastFromHistory(it) }
                         )
                     }
                 }
@@ -59,6 +63,11 @@ class RSSFeedActivity : ComponentActivity() {
         viewModel.foundPodcast.observe(this@RSSFeedActivity) { podcastId ->
             podcastId?.let { startPodcastDetailActivity(podcastId) }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.fetchLastPodcasts()
     }
 
     private fun startPodcastDetailActivity(podcastId: Long) {

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedUI.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedUI.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -24,14 +27,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import br.com.podesenvolver.R
+import br.com.podesenvolver.domain.Podcast
 import br.com.podesenvolver.presentation.SPACING_DEFAULT
 import br.com.podesenvolver.presentation.SPACING_MEDIUM
+import br.com.podesenvolver.presentation.SPACING_SMALL
 import br.com.podesenvolver.presentation.Typography
+import br.com.podesenvolver.presentation.rssFeed.ui.components.LastPodcastItem
 
 @Composable
 fun RSSFeedUI(
     fetchingPodcast: Boolean,
-    onSearch: (rssPodcastUrl: String) -> Unit
+    onSearch: (rssPodcastUrl: String) -> Unit,
+    lastPodcastsState: RSSFeedViewModel.LastPodcastState,
+    onClearPodcastFromHistory: (Podcast) -> Unit
 ) {
     var rssUrlText by remember { mutableStateOf("") }
     var searchButtonEnabled by remember { mutableStateOf(true) }
@@ -48,6 +56,7 @@ fun RSSFeedUI(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        Spacer(Modifier.padding(top = SPACING_DEFAULT))
         Image(painterResource(R.drawable.podcast), "icone de microfone do podesenvolver")
         Spacer(Modifier.padding(vertical = SPACING_DEFAULT))
         Text(
@@ -58,6 +67,7 @@ fun RSSFeedUI(
         Text("Feed RSS para Podcasts Apple")
         Spacer(Modifier.padding(vertical = SPACING_DEFAULT))
         OutlinedTextField(
+            enabled = fetchingPodcast.not(),
             value = rssUrlText,
             onValueChange = { rssUrlText = it },
             modifier = Modifier.fillMaxWidth(),
@@ -79,5 +89,39 @@ fun RSSFeedUI(
             },
             enabled = searchButtonEnabled
         ) { Text(stringResource(R.string.rss_feed_screen_search_button)) }
+
+        Column(Modifier.fillMaxHeight(), verticalArrangement = Arrangement.Center) {
+            when (lastPodcastsState) {
+                is RSSFeedViewModel.LastPodcastState.Loading -> LoadingLastPodcastList()
+                is RSSFeedViewModel.LastPodcastState.WithPodcasts -> LastPodcastList(
+                    lastPodcastsState.podcasts,
+                    onClearPodcastFromHistory
+                )
+
+                is RSSFeedViewModel.LastPodcastState.Empty -> EmptyLastPodcastList()
+            }
+        }
     }
+}
+
+@Composable
+fun LoadingLastPodcastList() {
+    Text(stringResource(R.string.rss_feed_screen_loading_last_podcasts))
+}
+
+@Composable
+fun EmptyLastPodcastList() {
+    Text(stringResource(R.string.rss_feed_screen_no_last_podcasts))
+}
+
+@Composable
+fun LastPodcastList(podcasts: List<Podcast>, onClearPodcast: (Podcast) -> Unit) {
+    Text(stringResource(R.string.rss_feed_screen_last_podcasts), style = Typography.titleMedium)
+    Spacer(Modifier.padding(vertical = SPACING_SMALL))
+    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        items(podcasts) {
+            LastPodcastItem(it, onClickClear = onClearPodcast)
+        }
+    }
+    Spacer(Modifier.padding(vertical = SPACING_DEFAULT))
 }

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedUI.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedUI.kt
@@ -39,7 +39,8 @@ fun RSSFeedUI(
     fetchingPodcast: Boolean,
     onSearch: (rssPodcastUrl: String) -> Unit,
     lastPodcastsState: RSSFeedViewModel.LastPodcastState,
-    onClearPodcastFromHistory: (Podcast) -> Unit
+    onClearPodcastFromHistory: (Podcast) -> Unit,
+    onClickPodcastInHistory: (Podcast) -> Unit
 ) {
     var rssUrlText by remember { mutableStateOf("") }
     var searchButtonEnabled by remember { mutableStateOf(true) }
@@ -95,6 +96,7 @@ fun RSSFeedUI(
                 is RSSFeedViewModel.LastPodcastState.Loading -> LoadingLastPodcastList()
                 is RSSFeedViewModel.LastPodcastState.WithPodcasts -> LastPodcastList(
                     lastPodcastsState.podcasts,
+                    onClickPodcastInHistory,
                     onClearPodcastFromHistory
                 )
 
@@ -115,12 +117,16 @@ fun EmptyLastPodcastList() {
 }
 
 @Composable
-fun LastPodcastList(podcasts: List<Podcast>, onClearPodcast: (Podcast) -> Unit) {
+fun LastPodcastList(
+    podcasts: List<Podcast>,
+    onClick: (Podcast) -> Unit,
+    onClearPodcast: (Podcast) -> Unit
+) {
     Text(stringResource(R.string.rss_feed_screen_last_podcasts), style = Typography.titleMedium)
     Spacer(Modifier.padding(vertical = SPACING_SMALL))
     LazyColumn(modifier = Modifier.fillMaxWidth()) {
         items(podcasts) {
-            LastPodcastItem(it, onClickClear = onClearPodcast)
+            LastPodcastItem(it, onClick = onClick, onClickClear = onClearPodcast)
         }
     }
     Spacer(Modifier.padding(vertical = SPACING_DEFAULT))

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedViewModel.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedViewModel.kt
@@ -7,7 +7,10 @@ import androidx.lifecycle.MutableLiveData
 import br.com.podesenvolver.R
 import br.com.podesenvolver.data.local.repository.LocalPodcastRepository
 import br.com.podesenvolver.data.network.repository.PodcastRepository
+import br.com.podesenvolver.domain.Podcast
 import br.com.podesenvolver.presentation.BaseViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import org.xml.sax.SAXParseException
 
 class RSSFeedViewModel(
@@ -21,6 +24,19 @@ class RSSFeedViewModel(
     val error = mutableStateOf<ErrorType?>(null)
     val fetchingPodcast = mutableStateOf(false)
 
+    private val _lastPodcasts = MutableStateFlow<LastPodcastState>(LastPodcastState.Loading)
+    val lastPodcasts: StateFlow<LastPodcastState> = _lastPodcasts
+
+    fun fetchLastPodcasts() {
+        _lastPodcasts.value = LastPodcastState.Loading
+        launch(errorBlock = { _lastPodcasts.value = LastPodcastState.Empty }) {
+            _lastPodcasts.value =
+                localPodcastRepository.getRecentPodcasts().takeIf { it.isNotEmpty() }?.let {
+                    LastPodcastState.WithPodcasts(it)
+                } ?: run { LastPodcastState.Empty }
+        }
+    }
+
     fun fetchPodcast(rssPodcastUrl: String) {
         fetchingPodcast.value = true
 
@@ -29,6 +45,13 @@ class RSSFeedViewModel(
             val podcastId = localPodcastRepository.savePodcast(podcast)
             _foundPodcast.postValue(podcastId)
             fetchingPodcast.value = false
+        }
+    }
+
+    fun deletePodcastFromHistory(podcast: Podcast) {
+        launch {
+            localPodcastRepository.deletePodcastById(podcast.cacheId)
+            fetchLastPodcasts()
         }
     }
 
@@ -53,5 +76,11 @@ class RSSFeedViewModel(
             title = R.string.rss_feed_screen_title_invalid_rss_error,
             description = R.string.rss_feed_screen_message_invalid_rss_error
         )
+    }
+
+    sealed class LastPodcastState {
+        data object Loading : LastPodcastState()
+        data object Empty : LastPodcastState()
+        data class WithPodcasts(val podcasts: List<Podcast>) : LastPodcastState()
     }
 }

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedViewModel.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedViewModel.kt
@@ -38,6 +38,10 @@ class RSSFeedViewModel(
         }
     }
 
+    fun selectPodcastFromHistory(podcast: Podcast) {
+        _foundPodcast.postValue(podcast.cacheId)
+    }
+
     fun fetchPodcast(rssPodcastUrl: String) {
         fetchingPodcast.value = true
 

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedViewModel.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/RSSFeedViewModel.kt
@@ -12,6 +12,7 @@ import br.com.podesenvolver.presentation.BaseViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.xml.sax.SAXParseException
+import java.net.ConnectException
 
 class RSSFeedViewModel(
     private val podcastRepository: PodcastRepository,
@@ -57,7 +58,7 @@ class RSSFeedViewModel(
 
     private fun handleGetPodcastError(throwable: Throwable) {
         error.value = when (throwable) {
-            is SAXParseException -> ErrorType.InvalidRss
+            is SAXParseException, is ConnectException -> ErrorType.InvalidRss
             else -> ErrorType.Generic
         }
 

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/preview/PreviewRSSFeedUI.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/preview/PreviewRSSFeedUI.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import br.com.podesenvolver.presentation.PodesenvolverTheme
 import br.com.podesenvolver.presentation.rssFeed.RSSFeedUI
+import br.com.podesenvolver.presentation.rssFeed.RSSFeedViewModel
 
 @Preview(showSystemUi = true)
 @Composable
@@ -18,7 +19,9 @@ fun PreviewRSSFeedUI() {
             Box(Modifier.padding(it)) {
                 RSSFeedUI(
                     fetchingPodcast = false,
-                    onSearch = { }
+                    onSearch = { },
+                    onClearPodcastFromHistory = {},
+                    lastPodcastsState = RSSFeedViewModel.LastPodcastState.Empty
                 )
             }
         }

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/preview/PreviewRSSFeedUI.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/preview/PreviewRSSFeedUI.kt
@@ -21,7 +21,8 @@ fun PreviewRSSFeedUI() {
                     fetchingPodcast = false,
                     onSearch = { },
                     onClearPodcastFromHistory = {},
-                    lastPodcastsState = RSSFeedViewModel.LastPodcastState.Empty
+                    lastPodcastsState = RSSFeedViewModel.LastPodcastState.Empty,
+                    onClickPodcastInHistory = {}
                 )
             }
         }

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/ui/components/LastPodcastItem.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/ui/components/LastPodcastItem.kt
@@ -29,7 +29,7 @@ fun LastPodcastItem(podcast: Podcast, onClick: (Podcast) -> Unit, onClickClear: 
         Modifier
             .fillMaxWidth()
             .clickable { onClick(podcast) },
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = Alignment.CenterVertically
     ) {
         AsyncImage(
             podcast.imageUrl,

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/ui/components/LastPodcastItem.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/ui/components/LastPodcastItem.kt
@@ -1,5 +1,6 @@
 package br.com.podesenvolver.presentation.rssFeed.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,10 +24,12 @@ import br.com.podesenvolver.presentation.SPACING_SMALL
 import coil3.compose.AsyncImage
 
 @Composable
-fun LastPodcastItem(podcast: Podcast, onClickClear: (Podcast) -> Unit) {
+fun LastPodcastItem(podcast: Podcast, onClick: (Podcast) -> Unit, onClickClear: (Podcast) -> Unit) {
     Row(
-        Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
+        Modifier
+            .fillMaxWidth()
+            .clickable { onClick(podcast) },
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(
             podcast.imageUrl,

--- a/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/ui/components/LastPodcastItem.kt
+++ b/app/src/main/java/br/com/podesenvolver/presentation/rssFeed/ui/components/LastPodcastItem.kt
@@ -1,0 +1,53 @@
+package br.com.podesenvolver.presentation.rssFeed.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import br.com.podesenvolver.R
+import br.com.podesenvolver.domain.Podcast
+import br.com.podesenvolver.presentation.SPACING_SMALL
+import coil3.compose.AsyncImage
+
+@Composable
+fun LastPodcastItem(podcast: Podcast, onClickClear: (Podcast) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            podcast.imageUrl,
+            "",
+            modifier = Modifier
+                .height(32.dp)
+                .padding(SPACING_SMALL)
+                .clip(RoundedCornerShape(4.dp))
+        )
+        Text(
+            podcast.title,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Spacer(Modifier.weight(1F))
+        IconButton({ onClickClear(podcast) }) {
+            Icon(
+                painterResource(R.drawable.round_clear_24),
+                "excluir histórico",
+                tint = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,9 @@
     <string name="rss_feed_screen_title_invalid_rss_error">Conteúdo desconhecido</string>
     <string name="rss_feed_screen_message_invalid_rss_error">O conteúdo entregue pela URL digitada é invalida ou não existe. Revise a URL e tente novamente.</string>
     <string name="rss_feed_screen_search_button">Buscar</string>
+    <string name="rss_feed_screen_last_podcasts">Últimos podcasts</string>
+    <string name="rss_feed_screen_loading_last_podcasts">Carregando histórico...</string>
+    <string name="rss_feed_screen_no_last_podcasts">Histórico de últimos podcasts vazio.</string>
 
     <!--    Tela de episode-->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="rss_feed_screen_message_invalid_rss_error">O conteúdo entregue pela URL digitada é invalida ou não existe. Revise a URL e tente novamente.</string>
     <string name="rss_feed_screen_search_button">Buscar</string>
     <string name="rss_feed_screen_last_podcasts">Últimos podcasts</string>
-    <string name="rss_feed_screen_loading_last_podcasts">Carregando histórico...</string>
+    <string name="rss_feed_screen_loading_last_podcasts">Carregando histórico…</string>
     <string name="rss_feed_screen_no_last_podcasts">Histórico de últimos podcasts vazio.</string>
 
     <!--    Tela de episode-->


### PR DESCRIPTION
**Descrição**

Implementa um histórico de buscas na tela de buscar do Feed RSS por URL.
Esse histórico lê o cache de RSS Feeds, ordena do mais recente ao mais antigo e seleciona apenas 5 para mostrar na pela principal de busca. Ao selecionar um desses registros, é reutilizado os dados gravados no momento da busca com sucesso, fazendo o usuário ser redirecionado para a tela de detalhes do podcast.

**Evidência**


https://github.com/user-attachments/assets/ca378b2c-75d8-49e1-81d6-7d7015114c9c

